### PR TITLE
make user search query case insensitive

### DIFF
--- a/server/model/user.go
+++ b/server/model/user.go
@@ -310,7 +310,7 @@ func SearchUsers(database *sql.DB, searchString string, draftId int) ([]User, er
                 )`
 
 	if searchString != "" {
-		query += " And Username Like CONCAT('%', CAST($2 As VARCHAR), '%');"
+		query += " And Username ILike CONCAT('%', CAST($2 As VARCHAR), '%');"
 	} else {
 		query += ";"
 	}


### PR DESCRIPTION
I am pretty sure this will not break anything else, I tested it a bit and it should just change the condition where player name is being searched for. I also am not sure if this is a feature you wanted but I think it is an improvement and it was easy to implement so here.

before
<img width="894" height="412" alt="image" src="https://github.com/user-attachments/assets/05faff92-f51a-4c8d-9713-899c9a8c1aca" />
after
<img width="632" height="669" alt="image" src="https://github.com/user-attachments/assets/391ee64b-3ad1-4623-9ff2-f8f62519e8ee" />
