### PR TITLE
adjust notifier

### DIFF
--- a/server/discord/discordWebhookBus.go
+++ b/server/discord/discordWebhookBus.go
@@ -2,6 +2,7 @@ package discord
 
 import (
 	"bytes"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -25,10 +26,12 @@ type AllowedMentions struct {
 }
 
 type NextPickDiscordEvent struct {
-	PreviousPickedTeam     string
-	PreviousPickIdentifier string
-	NextPickIdentifier     string
-	Webhook                string
+	PreviousPickedTeam    string
+	PreviousPickName      string
+	PreviousPickDiscordId sql.NullString
+	NextPickName          string
+	NextPickDiscordId     sql.NullString
+	Webhook               string
 }
 
 func NewBus() *DiscordWebhookBus {
@@ -42,12 +45,17 @@ func (d *DiscordWebhookBus) PostPreMatchNotification() error {
 }
 
 func (d *DiscordWebhookBus) PostPickNotification(event NextPickDiscordEvent) error {
-	var allowedMentions []string
-	nextId, found := strings.CutPrefix(event.NextPickIdentifier, "<@")
-	if found {
-		nextId = strings.Trim(nextId, "<@>")
-		allowedMentions = []string{
-			nextId,
+	previousIdentifier := event.PreviousPickName
+	if event.PreviousPickDiscordId.Valid {
+		previousIdentifier = fmt.Sprintf("<@%s>", event.PreviousPickDiscordId.String)
+	}
+
+	var allowedUserMentions []string
+	nextIdentifier := event.NextPickName
+	if event.NextPickDiscordId.Valid {
+		nextIdentifier = fmt.Sprintf("<@%s>", event.NextPickDiscordId.String)
+		allowedUserMentions = []string{
+			event.NextPickDiscordId.String,
 		}
 	}
 
@@ -55,12 +63,12 @@ func (d *DiscordWebhookBus) PostPickNotification(event NextPickDiscordEvent) err
 		Username: "Pick Notifier",
 		Content: fmt.Sprintf(
 			"%s has picked %s. %s it is your pick.",
-			event.PreviousPickIdentifier,
+			previousIdentifier,
 			strings.Trim(event.PreviousPickedTeam, "frc"),
-			event.NextPickIdentifier,
+			nextIdentifier,
 		),
 		AllowedMentions: AllowedMentions{
-			Users: allowedMentions,
+			Users: allowedUserMentions,
 		},
 	}
 

--- a/server/discord/discordWebhookBus.go
+++ b/server/discord/discordWebhookBus.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 )
 
 type DiscordWebhookBus struct {
@@ -13,8 +14,8 @@ type DiscordWebhookBus struct {
 }
 
 type DiscordWebhook struct {
-	Username string `json:"username"`
-	Content string `json:"content"`
+	Username        string          `json:"username"`
+	Content         string          `json:"content"`
 	AllowedMentions AllowedMentions `json:"allowed_mentions"`
 }
 
@@ -24,14 +25,14 @@ type AllowedMentions struct {
 }
 
 type NextPickDiscordEvent struct {
-	PreviousPickedTeam string
-	PreviousPickDiscordId string
-	DiscordId string
-	Webhook string
+	PreviousPickedTeam     string
+	PreviousPickIdentifier string
+	NextPickIdentifier     string
+	Webhook                string
 }
 
 func NewBus() *DiscordWebhookBus {
-	return &DiscordWebhookBus {
+	return &DiscordWebhookBus{
 		client: &http.Client{},
 	}
 }
@@ -41,18 +42,25 @@ func (d *DiscordWebhookBus) PostPreMatchNotification() error {
 }
 
 func (d *DiscordWebhookBus) PostPickNotification(event NextPickDiscordEvent) error {
-	webhook := DiscordWebhook {
+	var allowedMentions []string
+	nextId, found := strings.CutPrefix(event.NextPickIdentifier, "<@")
+	if found {
+		nextId = strings.Trim(nextId, "<@>")
+		allowedMentions = []string{
+			nextId,
+		}
+	}
+
+	webhook := DiscordWebhook{
 		Username: "Pick Notifier",
 		Content: fmt.Sprintf(
-			"<@%s> has picked %s. <@%s> it is your pick.",
-			event.PreviousPickDiscordId,
-			event.PreviousPickedTeam,
-			event.DiscordId,
+			"%s has picked %s. %s it is your pick.",
+			event.PreviousPickIdentifier,
+			strings.Trim(event.PreviousPickedTeam, "frc"),
+			event.NextPickIdentifier,
 		),
-		AllowedMentions: AllowedMentions {
-			Users: []string {
-				event.DiscordId,
-			},
+		AllowedMentions: AllowedMentions{
+			Users: allowedMentions,
 		},
 	}
 

--- a/server/discord/discordWebhookBus.go
+++ b/server/discord/discordWebhookBus.go
@@ -49,6 +49,7 @@ func (d *DiscordWebhookBus) PostPickNotification(event NextPickDiscordEvent) err
 	previousIdentifier := event.PreviousPickName
 	if event.PreviousPickDiscordId.Valid {
 		previousPickId := event.PreviousPickDiscordId.String
+		// discord IDs are unique 17+ digit integers, so we can validate them by checking length and seeing if they are numbers
 		_, err := strconv.ParseUint(previousPickId, 10, 64)
 		if len(previousPickId) >= 17 && err == nil {
 			previousIdentifier = fmt.Sprintf("<@%s>", previousPickId)
@@ -59,6 +60,7 @@ func (d *DiscordWebhookBus) PostPickNotification(event NextPickDiscordEvent) err
 	nextIdentifier := event.NextPickName
 	if event.NextPickDiscordId.Valid {
 		nextPickId := event.NextPickDiscordId.String
+		// discord IDs are unique 17+ digit integers, so we can validate them by checking length and seeing if they are numbers
 		_, err := strconv.ParseUint(nextPickId, 10, 64)
 		if len(nextPickId) >= 17 && err == nil {
 			nextIdentifier = fmt.Sprintf("<@%s>", nextPickId)

--- a/server/discord/discordWebhookBus.go
+++ b/server/discord/discordWebhookBus.go
@@ -62,6 +62,9 @@ func (d *DiscordWebhookBus) PostPickNotification(event NextPickDiscordEvent) err
 		_, err := strconv.ParseUint(nextPickId, 10, 64)
 		if len(nextPickId) >= 17 && err == nil {
 			nextIdentifier = fmt.Sprintf("<@%s>", nextPickId)
+			allowedUserMentions = []string{
+				nextPickId,
+			}
 		}
 	}
 

--- a/server/discord/discordWebhookBus.go
+++ b/server/discord/discordWebhookBus.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 )
 
@@ -47,22 +48,32 @@ func (d *DiscordWebhookBus) PostPreMatchNotification() error {
 func (d *DiscordWebhookBus) PostPickNotification(event NextPickDiscordEvent) error {
 	previousIdentifier := event.PreviousPickName
 	if event.PreviousPickDiscordId.Valid {
-		previousIdentifier = fmt.Sprintf("<@%s>", event.PreviousPickDiscordId.String)
+		previousPickId := event.PreviousPickDiscordId.String
+		_, err := strconv.ParseUint(previousPickId, 10, 64)
+		if len(previousPickId) >= 17 && err == nil {
+			previousIdentifier = fmt.Sprintf("<@%s>", previousPickId)
+		}
 	}
 
 	var allowedUserMentions []string
 	nextIdentifier := event.NextPickName
 	if event.NextPickDiscordId.Valid {
-		nextIdentifier = fmt.Sprintf("<@%s>", event.NextPickDiscordId.String)
-		allowedUserMentions = []string{
-			event.NextPickDiscordId.String,
+		nextPickId := event.NextPickDiscordId.String
+		_, err := strconv.ParseUint(nextPickId, 10, 64)
+		if len(nextPickId) >= 17 && err == nil {
+			nextIdentifier = fmt.Sprintf("<@%s>", nextPickId)
 		}
+	}
+
+	message := "%s has picked %s. %s it is your pick."
+	if previousIdentifier == nextIdentifier {
+		message = "%s has picked %s, and %s it is your turn again."
 	}
 
 	webhook := DiscordWebhook{
 		Username: "Pick Notifier",
 		Content: fmt.Sprintf(
-			"%s has picked %s. %s it is your pick.",
+			message,
 			previousIdentifier,
 			strings.Trim(event.PreviousPickedTeam, "frc"),
 			nextIdentifier,

--- a/server/model/discord.go
+++ b/server/model/discord.go
@@ -7,7 +7,7 @@ import (
 	"server/log"
 )
 
-func GetPlayerDiscordId(database *sql.DB, draftPlayerId int) (string, error) {
+func GetPlayerDiscordId(database *sql.DB, draftPlayerId int) (sql.NullString, error) {
 	query := `
 		Select
 			u.DiscordId
@@ -29,15 +29,10 @@ func GetPlayerDiscordId(database *sql.DB, draftPlayerId int) (string, error) {
 	var discordId sql.NullString
 	err = stmt.QueryRow(draftPlayerId).Scan(&discordId)
 	if err != nil {
-		return "", err
+		return sql.NullString{}, err
 	}
 
-	if !discordId.Valid {
-		return "", fmt.Errorf("Draft player with id %d does not have discord id set", draftPlayerId)
-	}
-
-	return discordId.String, nil
-
+	return discordId, nil
 }
 
 func GetDraftWebhook(database *sql.DB, draftId int) (string, error) {
@@ -67,7 +62,6 @@ func GetDraftWebhook(database *sql.DB, draftId int) (string, error) {
 	if !webhook.Valid {
 		return "", fmt.Errorf("Draft with id %d does not have discord webhook set", draftId)
 	}
-
 
 	return webhook.String, nil
 }

--- a/server/model/draft.go
+++ b/server/model/draft.go
@@ -537,6 +537,34 @@ func GetDraft(database *sql.DB, draftId int) (DraftModel, error) {
 	return draftModel, nil
 }
 
+func GetDraftPlayerName(database *sql.DB, draftPlayerId int) (string, error) {
+	query := `
+		Select
+			u.Username
+		From DraftPlayers dp
+		Inner Join Users u On u.UserUUID = dp.UserUUID
+		Where dp.Id = $1
+	`
+
+	assert := assert.CreateAssertWithContext("Get Player Discord Id")
+	assert.AddContext("Draft Player Id", draftPlayerId)
+	stmt, err := database.Prepare(query)
+	assert.NoError(err, "Failed to prepare query")
+	defer func() {
+		if err := stmt.Close(); err != nil {
+			log.WarnNoContext("GetDraftPlayerName: Failed to close statement", "error", err)
+		}
+	}()
+
+	var username string
+	err = stmt.QueryRow(draftPlayerId).Scan(&username)
+	if err != nil {
+		return "", err
+	}
+
+	return username, nil
+}
+
 func GetDraftPlayerPicks(database *sql.DB, draftPlayerId int) []Pick {
 	query := `SELECT
                 Picks.id,

--- a/server/model/draft.go
+++ b/server/model/draft.go
@@ -537,34 +537,6 @@ func GetDraft(database *sql.DB, draftId int) (DraftModel, error) {
 	return draftModel, nil
 }
 
-func GetDraftPlayerName(database *sql.DB, draftPlayerId int) (string, error) {
-	query := `
-		Select
-			u.Username
-		From DraftPlayers dp
-		Inner Join Users u On u.UserUUID = dp.UserUUID
-		Where dp.Id = $1
-	`
-
-	assert := assert.CreateAssertWithContext("Get Player Discord Id")
-	assert.AddContext("Draft Player Id", draftPlayerId)
-	stmt, err := database.Prepare(query)
-	assert.NoError(err, "Failed to prepare query")
-	defer func() {
-		if err := stmt.Close(); err != nil {
-			log.WarnNoContext("GetDraftPlayerName: Failed to close statement", "error", err)
-		}
-	}()
-
-	var username string
-	err = stmt.QueryRow(draftPlayerId).Scan(&username)
-	if err != nil {
-		return "", err
-	}
-
-	return username, nil
-}
-
 func GetDraftPlayerPicks(database *sql.DB, draftPlayerId int) []Pick {
 	query := `SELECT
                 Picks.id,

--- a/server/picking/pickManager.go
+++ b/server/picking/pickManager.go
@@ -3,6 +3,7 @@ package picking
 import (
 	"database/sql"
 	"errors"
+	"fmt"
 	"server/discord"
 	"server/log"
 	"server/model"
@@ -153,14 +154,32 @@ func (p *PickManager) MakePick(pick model.Pick) (bool, error) {
 			log.InfoNoContext("Making next pick available", "Draft Id", p.draftId)
 			model.MakePickAvailable(p.database, nextPickPlayer.Id, time.Now(), utils.GetPickExpirationTime(time.Now()))
 
-			currPickDiscordId, err := model.GetPlayerDiscordId(p.database, pick.Player)
+			currPickIdentifier, err := model.GetPlayerDiscordId(p.database, currentPick.Player)
 			if err != nil {
 				log.WarnNoContext("Could not get current pick draft player id", "Draft Player Id", pick.Player, "Error", err)
 			}
 
-			nextPickDiscordId, err := model.GetPlayerDiscordId(p.database, nextPickPlayer.Id)
+			if currPickIdentifier == "" {
+				currPickIdentifier, err = model.GetDraftPlayerName(p.database, currentPick.Player)
+				if err != nil {
+					log.WarnNoContext("Could not get current pick draft player name", "Draft Player Id", pick.Player, "Error", err)
+				}
+			} else {
+				currPickIdentifier = fmt.Sprintf("<@%s>", currPickIdentifier)
+			}
+
+			nextPickIdentifier, err := model.GetPlayerDiscordId(p.database, nextPickPlayer.Id)
 			if err != nil {
-				log.WarnNoContext("Could not get current pick draft player id", "Draft Player Id", pick.Player, "Error", err)
+				log.WarnNoContext("Could not get next pick draft player id", "Draft Player Id", nextPickPlayer.Id, "Error", err)
+			}
+
+			if nextPickIdentifier == "" {
+				nextPickIdentifier, err = model.GetDraftPlayerName(p.database, nextPickPlayer.Id)
+				if err != nil {
+					log.WarnNoContext("Could not get next pick draft player name", "Draft Player Id", nextPickPlayer.Id, "Error", err)
+				}
+			} else {
+				nextPickIdentifier = fmt.Sprintf("<@%s>", nextPickIdentifier)
 			}
 
 			draftWebhook, err := model.GetDraftWebhook(p.database, p.draftId)
@@ -169,10 +188,10 @@ func (p *PickManager) MakePick(pick model.Pick) (bool, error) {
 			}
 
 			event := discord.NextPickDiscordEvent{
-				PreviousPickedTeam:    pick.Pick.String,
-				PreviousPickDiscordId: currPickDiscordId,
-				DiscordId:             nextPickDiscordId,
-				Webhook:               draftWebhook,
+				PreviousPickedTeam:     pick.Pick.String,
+				PreviousPickIdentifier: currPickIdentifier,
+				NextPickIdentifier:     nextPickIdentifier,
+				Webhook:                draftWebhook,
 			}
 			go func() {
 				err = p.discordBus.PostPickNotification(event)

--- a/server/picking/pickManager.go
+++ b/server/picking/pickManager.go
@@ -3,7 +3,6 @@ package picking
 import (
 	"database/sql"
 	"errors"
-	"fmt"
 	"server/discord"
 	"server/log"
 	"server/model"
@@ -154,44 +153,43 @@ func (p *PickManager) MakePick(pick model.Pick) (bool, error) {
 			log.InfoNoContext("Making next pick available", "Draft Id", p.draftId)
 			model.MakePickAvailable(p.database, nextPickPlayer.Id, time.Now(), utils.GetPickExpirationTime(time.Now()))
 
-			currPickIdentifier, err := model.GetPlayerDiscordId(p.database, currentPick.Player)
+			currPickDiscordId, err := model.GetPlayerDiscordId(p.database, currentPick.Player)
 			if err != nil {
 				log.WarnNoContext("Could not get current pick draft player id", "Draft Player Id", pick.Player, "Error", err)
+				err = nil
 			}
 
-			if currPickIdentifier == "" {
-				currPickIdentifier, err = model.GetDraftPlayerName(p.database, currentPick.Player)
-				if err != nil {
-					log.WarnNoContext("Could not get current pick draft player name", "Draft Player Id", pick.Player, "Error", err)
-				}
-			} else {
-				currPickIdentifier = fmt.Sprintf("<@%s>", currPickIdentifier)
+			currPickName, err := model.GetDraftPlayerName(p.database, currentPick.Player)
+			if err != nil {
+				log.WarnNoContext("Could not get current pick draft player name", "Draft Player Id", pick.Player, "Error", err)
+				err = nil
 			}
 
-			nextPickIdentifier, err := model.GetPlayerDiscordId(p.database, nextPickPlayer.Id)
+			nextPickDiscordId, err := model.GetPlayerDiscordId(p.database, nextPickPlayer.Id)
 			if err != nil {
 				log.WarnNoContext("Could not get next pick draft player id", "Draft Player Id", nextPickPlayer.Id, "Error", err)
+				err = nil
 			}
 
-			if nextPickIdentifier == "" {
-				nextPickIdentifier, err = model.GetDraftPlayerName(p.database, nextPickPlayer.Id)
-				if err != nil {
-					log.WarnNoContext("Could not get next pick draft player name", "Draft Player Id", nextPickPlayer.Id, "Error", err)
-				}
-			} else {
-				nextPickIdentifier = fmt.Sprintf("<@%s>", nextPickIdentifier)
+			nextPickName, err := model.GetDraftPlayerName(p.database, nextPickPlayer.Id)
+			if err != nil {
+				log.WarnNoContext("Could not get next pick draft player name", "Draft Player Id", nextPickPlayer.Id, "Error", err)
+				err = nil
 			}
 
 			draftWebhook, err := model.GetDraftWebhook(p.database, p.draftId)
 			if err != nil {
 				log.WarnNoContext("Could not get draft webhook", "Draft Id", p.draftId, "Error", err)
+				err = nil
 			}
 
 			event := discord.NextPickDiscordEvent{
-				PreviousPickedTeam:     pick.Pick.String,
-				PreviousPickIdentifier: currPickIdentifier,
-				NextPickIdentifier:     nextPickIdentifier,
-				Webhook:                draftWebhook,
+				PreviousPickedTeam:    pick.Pick.String,
+				PreviousPickName:      currPickName,
+				PreviousPickDiscordId: currPickDiscordId,
+				NextPickName:          nextPickName,
+				NextPickDiscordId:     nextPickDiscordId,
+				Webhook:               draftWebhook,
 			}
 			go func() {
 				err = p.discordBus.PostPickNotification(event)

--- a/server/picking/pickManager.go
+++ b/server/picking/pickManager.go
@@ -159,11 +159,12 @@ func (p *PickManager) MakePick(pick model.Pick) (bool, error) {
 				err = nil
 			}
 
-			currPickName, err := model.GetDraftPlayerName(p.database, currentPick.Player)
+			currPickUser, err := model.GetDraftPlayerUser(p.database, currentPick.Player)
 			if err != nil {
 				log.WarnNoContext("Could not get current pick draft player name", "Draft Player Id", pick.Player, "Error", err)
 				err = nil
 			}
+			currPickName := currPickUser.Username
 
 			nextPickDiscordId, err := model.GetPlayerDiscordId(p.database, nextPickPlayer.Id)
 			if err != nil {
@@ -171,11 +172,12 @@ func (p *PickManager) MakePick(pick model.Pick) (bool, error) {
 				err = nil
 			}
 
-			nextPickName, err := model.GetDraftPlayerName(p.database, nextPickPlayer.Id)
+			nextPickUser, err := model.GetDraftPlayerUser(p.database, nextPickPlayer.Id)
 			if err != nil {
 				log.WarnNoContext("Could not get next pick draft player name", "Draft Player Id", nextPickPlayer.Id, "Error", err)
 				err = nil
 			}
+			nextPickName := nextPickUser.Username
 
 			draftWebhook, err := model.GetDraftWebhook(p.database, p.draftId)
 			if err != nil {


### PR DESCRIPTION
Uses the player's name if the discord ID is not present. This is a bit hacky and if you have a different suggestion I am all for it, but the best way I thought of was preformatting the id and then using the format to decide if it is a ping or a username. The alternative is adding a "has discord id" boolean to the struct passed to the discord bus and then using that to interpret the string and format it or leave it. This also reports teams as numbers, rather than team keys, but I can revert that if you prefer the team key. 

closes #158 